### PR TITLE
Add use-debug-io flag and gate debug dir creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ max_tokens = 8000
 
 [runtime]
 debug = true
-force = false
+use_debug_io = true
 executor_max_workers = 24
 min_delay_sec = 1
 ```

--- a/config.toml
+++ b/config.toml
@@ -59,7 +59,7 @@ max_retries  = 3
 
 [runtime]
 # Execution controls.
-force                = false         # re-run even if cached
+use_debug_io         = true          # use cached artifacts if available
 debug                = true          # extra debug behavior in some stages
 executor_max_workers = 24            # parallel workers
 min_delay_sec        = 1             # min delay between LLM requests

--- a/mark2mind/config_schema.py
+++ b/mark2mind/config_schema.py
@@ -70,7 +70,7 @@ class TracingConfig(BaseModel):
 
 
 class RuntimeConfig(BaseModel):
-    force: bool = True
+    use_debug_io: bool = False
     debug: bool = False
     executor_max_workers: Optional[int] = 24
     min_delay_sec: float = 0.15

--- a/mark2mind/main.py
+++ b/mark2mind/main.py
@@ -62,7 +62,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     # Runtime/debug
     p.add_argument("--debug", action="store_true", help="Enable verbose debug")
-    p.add_argument("--force", action="store_true", help="Force re-run (ignore cached artifacts)")
+    p.add_argument(
+        "--use-debug-io",
+        action="store_true",
+        help="Use cached artifacts from debug/<run_name> if present",
+    )
     p.add_argument(
         "--enable-tracing",
         action="store_true",
@@ -157,8 +161,8 @@ def main():
     # Prepare RunConfig
     cfg = RunConfig.from_app(app)
     cfg.run_id = run_id
-    if args.force:
-        cfg.force = True
+    if args.use_debug_io:
+        cfg.use_debug_io = True
     if args.max_workers is not None:
         cfg.executor_max_workers = args.max_workers
 

--- a/mark2mind/pipeline/core/artifacts.py
+++ b/mark2mind/pipeline/core/artifacts.py
@@ -29,8 +29,11 @@ class ArtifactStore:
         self.debug_dir = (self.debug_root / run_name).resolve()
         self.workspace_dir = (self.output_root / run_name).resolve()
 
+        # Remember whether we should write debug artifacts at all
+        self.enable_debug = enable_debug
+
         # Only create debug dir if enabled
-        if enable_debug:
+        if self.enable_debug:
             self.debug_dir.mkdir(parents=True, exist_ok=True)
         self.workspace_dir.mkdir(parents=True, exist_ok=True)
 
@@ -46,6 +49,8 @@ class ArtifactStore:
 
     # ----- debug artifacts ----------------------------------------------------
     def save_debug(self, name: str, obj: Any):
+        if not self.enable_debug:
+            return
         p = self.debug_dir / name
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(json.dumps(self._wrap(obj, "debug"), indent=2, ensure_ascii=False), encoding="utf-8")

--- a/mark2mind/pipeline/core/config.py
+++ b/mark2mind/pipeline/core/config.py
@@ -27,7 +27,7 @@ class RunConfig:
 
     steps: List[str] = field(default_factory=lambda: ["chunk", "tree", "cluster", "merge", "refine", "map"])
     run_id: str = "manual"
-    force: bool = False
+    use_debug_io: bool = False
     app: Optional[AppConfig] = None
 
     # execution knobs
@@ -59,7 +59,7 @@ class RunConfig:
             debug_root=Path(app.io.debug_dir),
             output_root=Path(app.io.output_dir),
             steps=steps,
-            force=app.runtime.force,
+            use_debug_io=app.runtime.use_debug_io,
             min_delay_sec=app.runtime.min_delay_sec,
             max_retries=app.runtime.max_retries,
             executor_max_workers=app.runtime.executor_max_workers,

--- a/mark2mind/pipeline/runner.py
+++ b/mark2mind/pipeline/runner.py
@@ -159,55 +159,121 @@ class StepRunner:
             ctx = RunContext(text=text)
 
             if "chunk" in self.cfg.steps:
-                ctx = self.chunk_stage.run(ctx, app.chunk.max_tokens, self.store, progress,
-                                           debug=self.debug, force=self.cfg.force)
-            else:
+                ctx = self.chunk_stage.run(
+                    ctx,
+                    app.chunk.max_tokens,
+                    self.store,
+                    progress,
+                    debug=self.debug,
+                    use_debug_io=self.cfg.use_debug_io,
+                )
+            elif self.cfg.use_debug_io:
                 loaded = self.store.load_debug("chunks.json")
                 if loaded is not None:
                     ctx.chunks = loaded
 
             if "reformat" in self.cfg.steps:
-                ctx = self.reformat_text_stage.run(ctx, self.store, progress, executor=self.executor, force=self.cfg.force)
+                ctx = self.reformat_text_stage.run(
+                    ctx,
+                    self.store,
+                    progress,
+                    executor=self.executor,
+                    use_debug_io=self.cfg.use_debug_io,
+                )
                 self.md_exporter.export_bullets(getattr(ctx, "reformat_outputs", []),
                     self.store.resolve_workspace_path("reformatted.md"))
                 self.console.log(f"✅ reformatted markdown saved to: {self.store.resolve_workspace_path('reformatted.md')}")
 
             if "clean_for_map" in self.cfg.steps:
-                ctx = self.clean_for_map_stage.run(ctx, self.store, progress, executor=self.executor, force=self.cfg.force)
+                ctx = self.clean_for_map_stage.run(
+                    ctx,
+                    self.store,
+                    progress,
+                    executor=self.executor,
+                    use_debug_io=self.cfg.use_debug_io,
+                )
                 self.md_exporter.export_bullets(getattr(ctx, "clean_for_map_outputs", []),
                     self.store.resolve_workspace_path("clean_for_map.md"))
                 self.console.log(f"✅ reformatted markdown saved to: {self.store.resolve_workspace_path('clean_for_map.md')}")
 
             if "bullets" in self.cfg.steps:
-                ctx = self.bullets_stage.run(ctx, self.store, progress, executor=self.executor, force=self.cfg.force)
+                ctx = self.bullets_stage.run(
+                    ctx,
+                    self.store,
+                    progress,
+                    executor=self.executor,
+                    use_debug_io=self.cfg.use_debug_io,
+                )
                 self.md_exporter.export_bullets(getattr(ctx, "bullets_outputs", []),
                     self.store.resolve_workspace_path("bullets.md"))
                 self.console.log(f"✅ Bulleted markdown saved to: {self.store.resolve_workspace_path('bullets.md')}")
 
             if "qa" in self.cfg.steps:
-                ctx = self.qa_stage.run(ctx, self.store, progress, executor=self.executor, force=self.cfg.force)
-                self.md_exporter.export_qa(ctx.chunks, self.store.resolve_workspace_path("qa.md"))
-            else:
+                ctx = self.qa_stage.run(
+                    ctx,
+                    self.store,
+                    progress,
+                    executor=self.executor,
+                    use_debug_io=self.cfg.use_debug_io,
+                )
+                self.md_exporter.export_qa(
+                    ctx.chunks, self.store.resolve_workspace_path("qa.md")
+                )
+            elif self.cfg.use_debug_io:
                 loaded = self.store.load_debug("chunks_with_qa.json")
                 if loaded is not None:
                     ctx.chunks = loaded
 
             if "tree" in self.cfg.steps:
-                ctx = self.tree_stage.run(ctx, self.store, progress, executor=self.executor, force=self.cfg.force)
+                ctx = self.tree_stage.run(
+                    ctx,
+                    self.store,
+                    progress,
+                    executor=self.executor,
+                    use_debug_io=self.cfg.use_debug_io,
+                )
             if "cluster" in self.cfg.steps:
-                ctx = self.cluster_stage.run(ctx, self.store, progress, force=self.cfg.force)
+                ctx = self.cluster_stage.run(
+                    ctx,
+                    self.store,
+                    progress,
+                    use_debug_io=self.cfg.use_debug_io,
+                )
             if "merge" in self.cfg.steps:
-                ctx = self.merge_stage.run(ctx, self.store, progress, executor=self.executor, force=self.cfg.force)
+                ctx = self.merge_stage.run(
+                    ctx,
+                    self.store,
+                    progress,
+                    executor=self.executor,
+                    use_debug_io=self.cfg.use_debug_io,
+                )
             if "refine" in self.cfg.steps:
-                ctx = self.refine_stage.run(ctx, self.store, progress, executor=self.executor, force=self.cfg.force)
+                ctx = self.refine_stage.run(
+                    ctx,
+                    self.store,
+                    progress,
+                    executor=self.executor,
+                    use_debug_io=self.cfg.use_debug_io,
+                )
 
             # NEW: parse QA markdown before mapping (if requested)
             if "qa_parse" in self.cfg.steps:
-                ctx = self.qa_from_md_stage.run(ctx, self.store, progress, force=self.cfg.force)
+                ctx = self.qa_from_md_stage.run(
+                    ctx,
+                    self.store,
+                    progress,
+                    use_debug_io=self.cfg.use_debug_io,
+                )
 
             if "map" in self.cfg.steps:
-                ctx = self.map_stage.run(ctx, self.store, progress, executor=self.executor,
-                                         force=self.cfg.force, map_batch_override=self.cfg.map_batch_override)
+                ctx = self.map_stage.run(
+                    ctx,
+                    self.store,
+                    progress,
+                    executor=self.executor,
+                    use_debug_io=self.cfg.use_debug_io,
+                    map_batch_override=self.cfg.map_batch_override,
+                )
 
                 if ctx.final_tree:
                     # aggregate tags from chunk results

--- a/mark2mind/pipeline/stages/bullets.py
+++ b/mark2mind/pipeline/stages/bullets.py
@@ -30,9 +30,10 @@ class BulletsStage:
             progress: ProgressReporter,
             *,
             executor: ExecutorProvider,   # ← accept executor like other stages
-            force: bool) -> RunContext:
+            use_debug_io: bool,
+        ) -> RunContext:
 
-        if not force:
+        if use_debug_io:
             loaded = store.load_debug(self.ARTIFACT)
             if loaded is not None:
                 setattr(ctx, "bullets_outputs", loaded)

--- a/mark2mind/pipeline/stages/chunk.py
+++ b/mark2mind/pipeline/stages/chunk.py
@@ -8,8 +8,17 @@ from mark2mind.utils.chunker import chunk_markdown
 class ChunkStage:
     ARTIFACT = "chunks.json"
 
-    def run(self, ctx: RunContext, max_tokens: int, store: ArtifactStore, progress: ProgressReporter, *, debug: bool, force: bool) -> RunContext:
-        if not force:
+    def run(
+        self,
+        ctx: RunContext,
+        max_tokens: int,
+        store: ArtifactStore,
+        progress: ProgressReporter,
+        *,
+        debug: bool,
+        use_debug_io: bool,
+    ) -> RunContext:
+        if use_debug_io:
             loaded = store.load_debug(self.ARTIFACT)
             if loaded is not None:
                 ctx.chunks = loaded

--- a/mark2mind/pipeline/stages/clean_for_map.py
+++ b/mark2mind/pipeline/stages/clean_for_map.py
@@ -31,9 +31,10 @@ class CleanForMapStage:
             progress: ProgressReporter,
             *,
             executor: ExecutorProvider,   # ← accept executor like other stages
-            force: bool) -> RunContext:
+            use_debug_io: bool,
+        ) -> RunContext:
 
-        if not force:
+        if use_debug_io:
             loaded = store.load_debug(self.ARTIFACT)
             if loaded is not None:
                 setattr(ctx, "clean_for_map_outputs", loaded)

--- a/mark2mind/pipeline/stages/cluster.py
+++ b/mark2mind/pipeline/stages/cluster.py
@@ -7,8 +7,15 @@ from ..core.progress import ProgressReporter
 class ClusterStage:
     ARTIFACT = "clusters.json"
 
-    def run(self, ctx: RunContext, store: ArtifactStore, progress: ProgressReporter, *, force: bool) -> RunContext:
-        if not force:
+    def run(
+        self,
+        ctx: RunContext,
+        store: ArtifactStore,
+        progress: ProgressReporter,
+        *,
+        use_debug_io: bool,
+    ) -> RunContext:
+        if use_debug_io:
             loaded = store.load_debug(self.ARTIFACT)
             if loaded is not None:
                 ctx.clustered = loaded

--- a/mark2mind/pipeline/stages/map_content.py
+++ b/mark2mind/pipeline/stages/map_content.py
@@ -59,7 +59,7 @@ class MapContentStage:
         progress: ProgressReporter,
         *,
         executor: ExecutorProvider,
-        force: bool,
+        use_debug_io: bool,
         map_batch_override: int | None,
     ) -> RunContext:
         if not ctx.final_tree:

--- a/mark2mind/pipeline/stages/merge.py
+++ b/mark2mind/pipeline/stages/merge.py
@@ -59,8 +59,16 @@ class MergeStage:
 
         return trees[0] if trees else None
 
-    def run(self, ctx: RunContext, store: ArtifactStore, progress: ProgressReporter, *, executor: ExecutorProvider, force: bool) -> RunContext:
-        if not force:
+    def run(
+        self,
+        ctx: RunContext,
+        store: ArtifactStore,
+        progress: ProgressReporter,
+        *,
+        executor: ExecutorProvider,
+        use_debug_io: bool,
+    ) -> RunContext:
+        if use_debug_io:
             loaded = store.load_debug(self.ARTIFACT)
             if loaded is not None:
                 ctx.cluster_trees = loaded

--- a/mark2mind/pipeline/stages/qa.py
+++ b/mark2mind/pipeline/stages/qa.py
@@ -26,8 +26,16 @@ class QAStage:
             "qa_a": AnswerQuestionsChain(llm, callbacks=self.callbacks),
         }
 
-    def run(self, ctx: RunContext, store: ArtifactStore, progress: ProgressReporter, *, executor: ExecutorProvider, force: bool) -> RunContext:
-        if not force:
+    def run(
+        self,
+        ctx: RunContext,
+        store: ArtifactStore,
+        progress: ProgressReporter,
+        *,
+        executor: ExecutorProvider,
+        use_debug_io: bool,
+    ) -> RunContext:
+        if use_debug_io:
             loaded = store.load_debug(self.ARTIFACT)
             if loaded is not None:
                 ctx.chunks = loaded

--- a/mark2mind/pipeline/stages/qa_from_markdown.py
+++ b/mark2mind/pipeline/stages/qa_from_markdown.py
@@ -7,8 +7,15 @@ from mark2mind.utils.qa_parser import parse_qa_markdown
 class QAFromMarkdownStage:
     ARTIFACT = "qa_blocks.json"
 
-    def run(self, ctx: RunContext, store: ArtifactStore, progress: ProgressReporter, *, force: bool) -> RunContext:
-        if not force:
+    def run(
+        self,
+        ctx: RunContext,
+        store: ArtifactStore,
+        progress: ProgressReporter,
+        *,
+        use_debug_io: bool,
+    ) -> RunContext:
+        if use_debug_io:
             loaded = store.load_debug(self.ARTIFACT)
             if loaded is not None:
                 setattr(ctx, "qa_blocks", loaded)

--- a/mark2mind/pipeline/stages/refine.py
+++ b/mark2mind/pipeline/stages/refine.py
@@ -49,8 +49,16 @@ class RefineStage:
 
         return cur[0]
 
-    def run(self, ctx: RunContext, store: ArtifactStore, progress: ProgressReporter, *, executor: ExecutorProvider, force: bool) -> RunContext:
-        if not force:
+    def run(
+        self,
+        ctx: RunContext,
+        store: ArtifactStore,
+        progress: ProgressReporter,
+        *,
+        executor: ExecutorProvider,
+        use_debug_io: bool,
+    ) -> RunContext:
+        if use_debug_io:
             loaded = store.load_debug(self.ARTIFACT)
             if loaded is not None:
                 ctx.final_tree = loaded

--- a/mark2mind/pipeline/stages/reformat.py
+++ b/mark2mind/pipeline/stages/reformat.py
@@ -31,9 +31,10 @@ class ReformatTextStage:
             progress: ProgressReporter,
             *,
             executor: ExecutorProvider,   # ← accept executor like other stages
-            force: bool) -> RunContext:
+            use_debug_io: bool,
+        ) -> RunContext:
 
-        if not force:
+        if use_debug_io:
             loaded = store.load_debug(self.ARTIFACT)
             if loaded is not None:
                 setattr(ctx, "reformat_outputs", loaded)

--- a/mark2mind/pipeline/stages/tree.py
+++ b/mark2mind/pipeline/stages/tree.py
@@ -29,12 +29,20 @@ class TreeStage:
             c[path] += int(b.get("token_count", 0)) or 1
         return [p for p,_ in c.most_common(3)]
 
-    def run(self, ctx: RunContext, store: ArtifactStore, progress: ProgressReporter, *, executor: ExecutorProvider, force: bool) -> RunContext:
-        if not force:
+    def run(
+        self,
+        ctx: RunContext,
+        store: ArtifactStore,
+        progress: ProgressReporter,
+        *,
+        executor: ExecutorProvider,
+        use_debug_io: bool,
+    ) -> RunContext:
+        if use_debug_io:
             loaded = store.load_debug(self.ARTIFACT)
             if loaded is not None:
                 ctx.chunk_results = loaded
-            return ctx
+                return ctx
 
         items = list(enumerate(ctx.chunks))
         task = progress.start("Trees per chunk", total=len(items))


### PR DESCRIPTION
## Summary
- prevent debug directories from being created unless debug is enabled
- replace `--force` with `--use-debug-io` and associated `use_debug_io` config
- allow pipeline stages to optionally read cached artifacts when `use_debug_io` is set

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a86fef81d0832284995d8a125f9aea