### PR TITLE
feat: add map_qa_onto_markmap recipe and markmap import stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ mark2mind --list-recipes
 | `mindmap_from_markdown`      | `mindmap`         | Chunk → Tree → Cluster → Merge → Refine → Mindmap                  |
 | `detailed_mindmap_from_markdown` | `detailed_mindmap` | Same as above + `map` stage (attaches content/code/tables/images to nodes) |
 | `mindmap_from_qa`            | `mindmap_from_qa` | Parse Q&A Markdown and build a mindmap with Q&A attached to nodes  |
+| `map_qa_onto_markmap`        | `map_qa_onto_markmap` | Map Q&A onto an existing Markmap                                   |
 | `qa_from_markdown`           | `qa`              | Chunk text, then generate Q&A per block                            |
 | `outline_markdown`           | `bullets`         | Bullet-point outline of Markdown                                   |
 | `reformat_markdown`          | `reformat`        | Rewrites Markdown into cleaner prose                               |
@@ -183,6 +184,16 @@ mark2mind --recipe mindmap_from_qa --input notes/qa.md
 ```
 
 → Output: `output/qa/mindmap.markmap.md`
+
+---
+
+### Map Q&A onto an existing Markmap
+
+```bash
+mark2mind --recipe map_qa_onto_markmap --input-markmap mindmap.md --input-qa qa.md --run-name MyTopic
+```
+
+→ Output: `output/MyTopic/MyTopic.mindmap.json`
 
 ---
 

--- a/mark2mind/config_schema.py
+++ b/mark2mind/config_schema.py
@@ -34,6 +34,8 @@ class IOConfig(BaseModel):
     """
     # Main entry: file or directory (mode is inferred)
     input: Optional[str] = None
+    # Optional extra input for importing an existing Markmap
+    markmap_input: Optional[str] = None
 
     # Workspace roots; all artifacts write under <output_dir>/<run_name>/
     output_dir: str = "output"
@@ -94,6 +96,7 @@ class PresetsConfig(BaseModel):
         "subs_list": ["subs_list"],
         "subs_merge": ["subs_merge"],
         "mindmap_from_qa": ["chunk", "tree", "cluster", "merge", "refine", "qa_parse", "map"],
+        "map_qa_onto_markmap": ["qa_parse", "import_markmap", "map"],
     }
 
 

--- a/mark2mind/main.py
+++ b/mark2mind/main.py
@@ -42,6 +42,8 @@ def build_parser() -> argparse.ArgumentParser:
 
     # Common overrides
     p.add_argument("--input", dest="input_override", type=str, help="Override [io].input")
+    p.add_argument("--input-qa", dest="input_qa", type=str, help="QA markdown input (for map_qa_onto_markmap)")
+    p.add_argument("--input-markmap", dest="input_markmap", type=str, help="Existing Markmap markdown to import")
     p.add_argument("--run-name", dest="run_name_override", type=str, help="Override [io].run_name")
     p.add_argument("--output-dir", type=str, help="Override [io].output_dir")
     p.add_argument("--debug-dir", type=str, help="Override [io].debug_dir")
@@ -114,6 +116,10 @@ def main():
     # Overrides
     if args.input_override:
         app.io.input = args.input_override
+    if args.input_qa:
+        app.io.input = args.input_qa
+    if args.input_markmap:
+        app.io.markmap_input = args.input_markmap
     # ✅ validate now, after overrides
     if not app.io.input:
         raise ValueError(
@@ -123,6 +129,14 @@ def main():
     input_path = Path(app.io.input)
     if not input_path.exists():
         raise FileNotFoundError(f"Input path not found: {app.io.input}")
+
+    need_markmap = "import_markmap" in app.pipeline.steps
+    if need_markmap and not app.io.markmap_input:
+        raise ValueError("Missing Markmap input. Use --input-markmap")
+    if app.io.markmap_input:
+        markmap_path = Path(app.io.markmap_input)
+        if not markmap_path.exists():
+            raise FileNotFoundError(f"Markmap input not found: {app.io.markmap_input}")
 
     if not app.io.run_name:
         app.io.run_name = _derive_run_name(input_path)

--- a/mark2mind/pipeline/core/config.py
+++ b/mark2mind/pipeline/core/config.py
@@ -21,6 +21,7 @@ class RunConfig:
     run_name: str
     input_path: Path
     is_dir_mode: bool
+    markmap_input_path: Optional[Path] = None
 
     debug_root: Path = Path("debug")
     output_root: Path = Path("output")
@@ -51,11 +52,13 @@ class RunConfig:
 
         input_path = Path(app.io.input)
         is_dir_mode = input_path.is_dir()
+        markmap_input = Path(app.io.markmap_input) if app.io.markmap_input else None
 
         return cls(
             run_name=app.io.run_name or input_path.stem,
             input_path=input_path,
             is_dir_mode=is_dir_mode,
+            markmap_input_path=markmap_input,
             debug_root=Path(app.io.debug_dir),
             output_root=Path(app.io.output_dir),
             steps=steps,

--- a/mark2mind/pipeline/runner.py
+++ b/mark2mind/pipeline/runner.py
@@ -29,6 +29,7 @@ from .stages import (
     RefineStage,
     MapContentStage,
     QAFromMarkdownStage,
+    ImportMarkmapStage,
 )
 from .export import MarkdownExporter, JSONExporter
 
@@ -95,6 +96,7 @@ class StepRunner:
         self.subs_list_stage = SubtitlesListStage()
         self.subs_merge_stage = SubtitlesMergeStage()
         self.qa_from_md_stage = QAFromMarkdownStage()
+        self.import_markmap_stage = ImportMarkmapStage()
 
         self.md_exporter = MarkdownExporter()
         self.json_exporter = JSONExporter()
@@ -262,6 +264,15 @@ class StepRunner:
                     ctx,
                     self.store,
                     progress,
+                    use_debug_io=self.cfg.use_debug_io,
+                )
+
+            if "import_markmap" in self.cfg.steps:
+                ctx = self.import_markmap_stage.run(
+                    ctx,
+                    self.store,
+                    progress,
+                    markmap_path=str(self.cfg.markmap_input_path) if self.cfg.markmap_input_path else None,
                     use_debug_io=self.cfg.use_debug_io,
                 )
 

--- a/mark2mind/pipeline/stages/__init__.py
+++ b/mark2mind/pipeline/stages/__init__.py
@@ -6,3 +6,4 @@ from .merge import MergeStage
 from .refine import RefineStage
 from .map_content import MapContentStage
 from .qa_from_markdown import QAFromMarkdownStage
+from .import_markmap import ImportMarkmapStage

--- a/mark2mind/pipeline/stages/import_markmap.py
+++ b/mark2mind/pipeline/stages/import_markmap.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+from pathlib import Path
+import re
+from typing import Dict, List, Tuple
+
+from ..core.context import RunContext
+from ..core.artifacts import ArtifactStore
+from ..core.progress import ProgressReporter
+from mark2mind.utils.tree_helper import assign_node_ids
+
+
+class ImportMarkmapStage:
+    """Load an existing Markmap markdown file into ctx.final_tree."""
+
+    ARTIFACT = "import_markmap_tree.json"
+
+    def _parse(self, text: str) -> Dict:
+        lines = text.splitlines()
+        root: Dict | None = None
+        stack: List[Tuple[int, Dict]] = []  # (depth, node)
+        heading_re = re.compile(r"^(#{1,6})\s+(.*)")
+        bullet_re = re.compile(r"^(?P<indent>\s*)-\s+(.*)")
+        link_re = re.compile(r"\[(.+?)\]\(.*?\)")
+
+        for line in lines:
+            if not line.strip():
+                continue
+            h = heading_re.match(line)
+            if h:
+                level = len(h.group(1)) - 1  # depth 0 for '#'
+                title = h.group(2).strip()
+                mlink = link_re.fullmatch(title)
+                if mlink:
+                    title = mlink.group(1)
+                node = {"title": title, "children": []}
+                if level == 0 or not stack:
+                    root = node
+                    stack = [(0, root)]
+                else:
+                    while stack and stack[-1][0] >= level:
+                        stack.pop()
+                    parent = stack[-1][1] if stack else root
+                    (parent.setdefault("children", [])).append(node)
+                    stack.append((level, node))
+                continue
+            b = bullet_re.match(line)
+            if b:
+                indent = len(b.group("indent"))
+                depth = indent // 2
+                title = b.group(2).strip()
+                mlink = link_re.fullmatch(title)
+                if mlink:
+                    title = mlink.group(1)
+                node = {"title": title, "children": []}
+                if not stack:
+                    root = node
+                    stack = [(depth, node)]
+                else:
+                    while stack and stack[-1][0] >= depth:
+                        stack.pop()
+                    parent = stack[-1][1] if stack else root
+                    (parent.setdefault("children", [])).append(node)
+                    stack.append((depth, node))
+        if not root:
+            raise ValueError("Invalid Markmap: missing root heading or bullet")
+        return root
+
+    def run(
+        self,
+        ctx: RunContext,
+        store: ArtifactStore,
+        progress: ProgressReporter,
+        *,
+        markmap_path: str | None,
+        use_debug_io: bool,
+    ) -> RunContext:
+        if not markmap_path:
+            raise FileNotFoundError("Missing markmap input. Provide --input-markmap")
+        path = Path(markmap_path)
+        if not path.exists():
+            raise FileNotFoundError(f"Markmap file not found: {markmap_path}")
+
+        if use_debug_io:
+            loaded = store.load_debug(self.ARTIFACT)
+            if loaded is not None:
+                ctx.final_tree = loaded
+                return ctx
+
+        task = progress.start("Importing Markmap", total=1)
+        text = path.read_text(encoding="utf-8")
+        tree = self._parse(text)
+        assign_node_ids(tree)
+        ctx.final_tree = tree
+        store.save_debug(self.ARTIFACT, tree)
+        progress.advance(task)
+        progress.finish(task)
+        return ctx

--- a/mark2mind/recipes/__init__.py
+++ b/mark2mind/recipes/__init__.py
@@ -17,6 +17,7 @@ CANONICAL: Dict[str, str] = {
     "outline_markdown": "outline_markdown.toml",
     # NEW:
     "mindmap_from_qa": "mindmap_from_qa.toml",
+    "map_qa_onto_markmap": "map_qa_onto_markmap.toml",
 }
 
 ALIASES: Dict[str, str] = {

--- a/mark2mind/recipes/map_qa_onto_markmap.toml
+++ b/mark2mind/recipes/map_qa_onto_markmap.toml
@@ -1,0 +1,22 @@
+# FILE: mark2mind/mark2mind/recipes/map_qa_onto_markmap.toml
+# Map a QA markdown file onto an existing Markmap tree
+[pipeline]
+steps = ["qa_parse","import_markmap","map"]
+
+[io]
+output_dir = "output"
+debug_dir  = "debug"
+
+[chunk]
+tokenizer_name = "gpt2"
+max_tokens     = 1024
+overlap_tokens = 0
+
+[llm]
+provider     = "deepseek"
+model        = "deepseek-chat"
+api_key_env  = "DEEPSEEK_API_KEY"
+temperature  = 0.3
+max_tokens   = 8192
+timeout      = 1000000
+max_retries  = 3


### PR DESCRIPTION
## Summary
- add ImportMarkmapStage to parse existing Markmap markdown into internal tree
- wire up map_qa_onto_markmap recipe and CLI flags --input-qa/--input-markmap
- document new workflow in README and recipe registry

## Testing
- `python -m mark2mind.main --list-recipes`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b46099fe7c832280e6bd55fa564bab