### PR TITLE
Add slug-based wikilinks and link validation

### DIFF
--- a/mark2mind/pipeline/runner.py
+++ b/mark2mind/pipeline/runner.py
@@ -324,7 +324,6 @@ class StepRunner:
                     })
 
                     # Filenames based on run_name (e.g., intro → intro.*)
-                    from mark2mind.utils.exporters import to_camel_nospace
                     base_name = to_camel_nospace(self.cfg.run_name)
                     json_out_path = self.store.resolve_workspace_path(f"{base_name}.mindmap.json")
                     markmap_out_path = self.store.resolve_workspace_path(f"{base_name}.markmap.md")
@@ -346,6 +345,13 @@ class StepRunner:
                         link_folder_name=base_name,
                     )
                     self.console.log(f"✅ Markmap markdown saved to: {markmap_out_path}")
+                    # Link validator
+                    problems = validate_pages(pages_dir)
+                    if problems:
+                        self.console.log(f"⚠️ Link check found {len(problems)} issues")
+                        self.store.write_text("link_validation.txt", "\n".join(problems))
+                    else:
+                        self.console.log("✅ All wikilinks resolve to existing pages")
 
                     # Any “no-refs” or auxiliary variants go into DEBUG only
                     def _strip_content_refs(node: Dict[str, Any]) -> Dict[str, Any]:

--- a/mark2mind/pipeline/stages/enrich_notes.py
+++ b/mark2mind/pipeline/stages/enrich_notes.py
@@ -11,10 +11,25 @@ from ..core.llm_pool import LLMFactoryPool
 from ..core.executor_provider import ExecutorProvider
 from mark2mind.chains.note_generation_chains import NoteLeafChain, NoteBranchChain, PrereqPickChain
 from mark2mind.utils.tree_helper import assign_node_ids
+from mark2mind.utils.slugs import node_slug
 from datetime import datetime
+import re
 
-LEAF_SECTIONS = ["## Summary","## Purpose","## Concept","## Pre-reqs","## How-to","## Reference","## Checks","## Failure modes","## Security/Quality","## See also"]
-BRANCH_SECTIONS = ["## Scope","## Map","## Choice guide","## Workflows","## Cross-cutting pitfalls","## Children"]
+# Required section lists now contain no link lists; Dataview renders links.
+LEAF_SECTIONS = [
+    "Summary",
+    "Why it matters",
+    "Core steps",
+    "Checks",
+    "Failure modes",
+    "Examples",
+]
+BRANCH_SECTIONS = [
+    "Summary",
+    "When to use",
+    "Decision points",
+    "Children",
+]
 
 class EnrichMarkmapNotesStage:
     ARTIFACT = "enriched_tree.json"
@@ -62,25 +77,57 @@ class EnrichMarkmapNotesStage:
             lv.setdefault(d, []).append(nid)
         return lv
 
-    def _mk_frontmatter(self, node_id: str, ntype: str, parent_link: str|None, child_links: List[str], prereq_links: List[str], summary: str, model_id: str, run_id: str) -> str:
-        lines = ["---",
-                 f"id: {node_id}",
-                 f"type: {ntype}",
-                 f"parent: {parent_link if parent_link else ''}".rstrip()]
+    def _mk_frontmatter(
+        self,
+        node_id: str,
+        ntype: str,
+        parent_link: str | None,
+        child_links: List[str],
+        prereq_links: List[str],
+        see_also_links: List[str],
+        summary: str,
+        model_id: str,
+        run_id: str,
+    ) -> str:
+        lines = [
+            "---",
+            f"id: {node_id}",
+            f"type: {ntype}",
+            *( [f"parent: {parent_link}"] if parent_link else [] ),
+        ]
         lines.append("children:")
         for c in child_links:
             lines.append(f"  - {c}")
         lines.append("prereqs:")
         for p in prereq_links:
             lines.append(f"  - {p}")
+        lines.append("see_also:")
+        for s in see_also_links:
+            lines.append(f"  - {s}")
         lines.append(f"summary: {summary}")
         lines.append(f"model: {model_id}")
         lines.append(f"run_id: {run_id}")
         lines.append("---")
         return "\n".join(lines)
 
-    def _wikilink(self, path_str: str) -> str:
-        return f"[[{path_str}]]"
+    def _wikilink(self, slug: str, folder: str | None = None) -> str:
+        return f"[[{folder}/{slug}]]" if folder else f"[[{slug}]]"
+
+    def _fix_wikilinks(self, body: str, allowed: dict[str, str]) -> str:
+        # allowed maps lower(slug) -> CanonicalSlug
+        def repl(m: re.Match) -> str:
+            raw = m.group(1).strip()
+            target = raw.split("|", 1)[0].split("/", 1)[0]
+            k = target.lower()
+            if k in allowed:
+                canon = allowed[k]
+                alias = None
+                if "|" in raw:
+                    alias = raw.split("|", 1)[1]
+                return f"[[{canon}|{alias}]]" if alias else f"[[{canon}]]"
+            return raw
+
+        return re.sub(r"\[\[([^\]]+)\]\]", lambda m: repl(m), body)
 
     def run(self, ctx: RunContext, store: ArtifactStore, progress: ProgressReporter, *, use_debug_io: bool, executor: ExecutorProvider) -> RunContext:
         if not ctx.final_tree:
@@ -89,14 +136,24 @@ class EnrichMarkmapNotesStage:
         assign_node_ids(ctx.final_tree)
         nodes, title_path, graph_children, graph_parent, depth_map = self._walk(ctx.final_tree)
         ids = [n["id"] for n in nodes]
+
+        # Slug index
+        id2slug: dict[str, str] = {}
+        for item in nodes:
+            n = item["node"]
+            id2slug[item["id"]] = node_slug(n.get("title"))
+        allowed_links_list = sorted(id2slug.values())
+        allowed_links = {s.lower(): s for s in allowed_links_list}
+        allowed_links_str = ", ".join(allowed_links_list)
+
         levels = self._levels(ids, depth_map)
         llm = self.llm_pool.get()
         leaf_chain = NoteLeafChain(llm, callbacks=self.callbacks)
         branch_chain = NoteBranchChain(llm, callbacks=self.callbacks)
         prereq_chain = PrereqPickChain(llm, callbacks=self.callbacks)
 
-        # compute path strings once
-        path_str = {nid: title_path[nid].replace("/", "/") for nid in ids}
+        # compute path strings once (for prompt context only)
+        path_str = {nid: title_path[nid] for nid in ids}
 
         # generate leaves deepest-first
         deepest = sorted(levels.keys(), reverse=True)
@@ -104,7 +161,7 @@ class EnrichMarkmapNotesStage:
         model_id = getattr(llm, "model", "provider/model")
         run_id = getattr(ctx, "run_id", "manual")
 
-        def gen_leaf(nid: str) -> Tuple[str,str]:
+        def gen_leaf(nid: str) -> Tuple[str, str]:
             n = next(x["node"] for x in nodes if x["id"] == nid)
             required_sections = "\n".join(LEAF_SECTIONS)
             parent_id = graph_parent.get(nid)
@@ -115,8 +172,9 @@ class EnrichMarkmapNotesStage:
                 node_path=path_str[nid],
                 parent_path=parent_path,
                 required_sections=required_sections,
-                style_rules="summary<=80; see_also<=5; no_frontmatter",
-                known_facts=""
+                allowed_links=allowed_links_str,
+                style_rules="summary<=80; no_frontmatter",
+                known_facts="",
             )
             # extract summary line
             sum_line = ""
@@ -144,6 +202,8 @@ class EnrichMarkmapNotesStage:
                     progress.advance(t)
             progress.finish(t)
             for nid, (body, summary) in results.items():
+                n = next(x["node"] for x in nodes if x["id"] == nid)
+                n["_generated_body"] = self._fix_wikilinks(body, allowed_links)
                 summaries[nid] = summary
 
         # generate branches/hubs upward
@@ -164,7 +224,8 @@ class EnrichMarkmapNotesStage:
                     node_path=path_str[nid],
                     children_digest="\n".join(digest),
                     required_sections="\n".join(BRANCH_SECTIONS),
-                    transclusion_hint=transclusion_hint
+                    transclusion_hint=transclusion_hint,
+                    allowed_links=allowed_links_str,
                 )
                 # store in summaries optionally blank
                 summaries[nid] = summaries.get(nid,"")
@@ -175,7 +236,7 @@ class EnrichMarkmapNotesStage:
                     "markdown": "",  # frontmatter+body injected later
                     "created_at": datetime.utcnow().isoformat(timespec="seconds")+"Z",
                 })
-                n["_generated_body"] = body  # stash temporarily
+                n["_generated_body"] = self._fix_wikilinks(body, allowed_links)
                 progress.advance(t)
             progress.finish(t)
 
@@ -215,28 +276,69 @@ class EnrichMarkmapNotesStage:
             target_node = next(x["node"] for x in nodes if x["id"]==nid)
             target_node["_prereq_ids"] = chosen
 
+        # See-also selection: siblings → parent → cousins (excluding prereqs)
+        see_also_ids: dict[str, list[str]] = {}
+        for nid in ids:
+            prs = set(next(x["node"] for x in nodes if x["id"] == nid).get("_prereq_ids") or [])
+            parent = graph_parent.get(nid)
+            sibs = [s for s in (graph_children.get(parent, []) if parent else []) if s != nid]
+            order: list[str] = []
+            order.extend([s for s in sibs if s not in prs])
+            if parent and parent not in prs:
+                order.append(parent)
+            grand = graph_parent.get(parent) if parent else None
+            if grand:
+                for ps in graph_children.get(grand, []):
+                    for c in graph_children.get(ps, []):
+                        if c != nid and c not in prs:
+                            order.append(c)
+            dedup: list[str] = []
+            seen: set[str] = set()
+            for x in order:
+                if x not in seen:
+                    seen.add(x)
+                    dedup.append(x)
+            see_also_ids[nid] = dedup[:5]
+
         # embed frontmatter+body into a single synthetic content_ref per node
         for nid in ids:
             n = next(x["node"] for x in nodes if x["id"]==nid)
             ntype = self._node_type(nid, depth_map, graph_children)
             parent_id = graph_parent.get(nid)
-            parent_link = self._wikilink(path_str[parent_id]) if parent_id else ""
-            child_links = [self._wikilink(path_str[c]) for c in graph_children.get(nid,[])]
-            prereq_links = [self._wikilink(path_str[p]) for p in (n.get("_prereq_ids") or [])]
+            parent_link = self._wikilink(id2slug[parent_id]) if parent_id else None
+            child_links = [self._wikilink(id2slug[c]) for c in graph_children.get(nid, [])]
+            prereq_links = [self._wikilink(id2slug[p]) for p in (n.get("_prereq_ids") or [])]
+            see_also_links = [self._wikilink(id2slug[s]) for s in see_also_ids.get(nid, [])]
             fm = self._mk_frontmatter(
                 node_id=nid,
                 ntype=ntype,
                 parent_link=parent_link,
                 child_links=child_links,
                 prereq_links=prereq_links,
-                summary=(summaries.get(nid,"") or "")[:480],
+                see_also_links=see_also_links,
+                summary=(summaries.get(nid, "") or "")[:480],
                 model_id=str(model_id),
                 run_id=str(run_id),
             )
-            body = n.pop("_generated_body", f"# {n.get('title') or 'Untitled'}\n")
-            if not body.lstrip().startswith("# "):
-                body = f"# {n.get('title') or 'Untitled'}\n{body}"
-            synthetic = f"{fm}\n{body}"
+            body = n.pop("_generated_body", "# Untitled")
+            if not body.lstrip().startswith("#"):
+                body = f"# {(n.get('title') or 'Untitled')}\n\n{body}"
+
+            dv_see = (
+                "## See also\n"
+                "```dataviewjs\n"
+                "const L = dv.current().see_also ?? [];\n"
+                "if (L.length) dv.list(L);\n"
+                "```\n\n"
+            )
+            dv_pre = (
+                "## Pre-reqs\n"
+                "```dataviewjs\n"
+                "const P = dv.current().prereqs ?? [];\n"
+                "if (P.length) dv.list(P);\n"
+                "```\n\n"
+            )
+            synthetic = f"{fm}\n{dv_see}{dv_pre}{body}"
             # ensure only one synthetic note ref and keep existing refs
             refs = n.setdefault("content_refs", [])
             # put synthetic first

--- a/mark2mind/prompts/mindmap/note_branch.txt
+++ b/mark2mind/prompts/mindmap/note_branch.txt
@@ -1,5 +1,4 @@
-You write Obsidian-ready Markdown. Strict section order. No duplication beyond this node. Use wikilinks [[Full/Path|Alias]]. Be concise and exact. No frontmatter. No HTML.
-Do not restate child internals. Link or transclude.
+You write Obsidian-ready Markdown.
 
 TITLE: {node_title}
 PATH: {node_path}
@@ -10,10 +9,18 @@ Children:
 Write the following sections in this exact order:
 {required_sections}
 
-Rules:
-- Do not repeat options, flags, or procedures from children.
-- Prefer comparisons, decisions, and workflows.
-- In "Children" section, include a bullet for each direct child with a wikilink.
-{transclusion_hint}
+Strict rules:
+- Markdown only. Start with "# {node_title}".
+- Required sections only, in order. No YAML, no HTML.
+- Do not restate child details; link or transclude instead.
+- Summarize scope, workflows, and decision criteria.
+- "Children" section must be a bullet list with wikilinks.
+- Only link to these slugs if linking: {allowed_links}. If a concept has no allowed slug, write plain text.
 
-Output: Markdown only, starting with "# {node_title}" then the sections.
+Rules:
+- Focus on comparisons, decision points, and cross-cutting insights.
+- In "Children", include exactly one bullet wikilink per direct child.
+- If transclusion is requested, include the summary transclusions after all sections.
+{transclusion_hint}
+Output:
+Markdown only. Begin with "# {node_title}" then the sections in order.

--- a/mark2mind/prompts/mindmap/note_leaf.txt
+++ b/mark2mind/prompts/mindmap/note_leaf.txt
@@ -1,4 +1,4 @@
-You write Obsidian-ready Markdown. Strict section order. No duplication beyond this node. Use wikilinks [[Full/Path|Alias]]. Be concise and exact. No frontmatter. No HTML.
+You write Obsidian-ready Markdown.
 
 TITLE: {node_title}
 PATH: {node_path}
@@ -7,10 +7,23 @@ PARENT: {parent_path}
 Write the following sections in this exact order:
 {required_sections}
 
-Rules:
-- Teach this topic end-to-end.
-- Prefer generic, version-stable guidance.
-- Use wikilinks for references to other notes, format [[{path}]].
-- Do not include YAML frontmatter.
+Strict rules:
+- Markdown only.
+- Start with "# {node_title}".
+- Use the required sections in exact order, no extras.
+- No YAML frontmatter. No HTML.
+- No repetition across sections.
+- Use wikilinks like [[Full/Path|Alias]].
+- Summary ≤ 80 words, one line. See also ≤ 5 items.
+- Only link to these slugs if linking: {allowed_links}. If a concept has no allowed slug, write plain text.
 
-Output: Markdown only, starting with "# {node_title}" then the sections.
+Rules:
+- Teach this topic independently.
+- Prefer generic, durable knowledge over version-specific flags.
+- In "Checks" provide 2–5 minimal self-tests.
+- In "Failure modes" cover the most likely pitfalls only.
+- Use bullet points where clearer.
+- Do not add or reorder sections.
+
+Output:
+Markdown only. Begin with "# {node_title}" then the sections in the listed order.

--- a/mark2mind/utils/slugs.py
+++ b/mark2mind/utils/slugs.py
@@ -1,0 +1,5 @@
+from mark2mind.utils.exporters import to_camel_nospace as _camel
+
+
+def node_slug(title: str | None) -> str:
+    return _camel(title or "Untitled")

--- a/mark2mind/utils/validate_links.py
+++ b/mark2mind/utils/validate_links.py
@@ -1,0 +1,18 @@
+import re
+from pathlib import Path
+
+
+def collect_wikilinks(text: str) -> set[str]:
+    return {m.group(1).split("|", 1)[0].split("/", 1)[-1] for m in re.finditer(r"\[\[([^\]]+)\]\]", text)}
+
+
+def validate_pages(pages_dir: Path) -> list[str]:
+    files = list(pages_dir.glob("*.md"))
+    slugs = {p.stem for p in files}
+    missing = []
+    for p in files:
+        s = collect_wikilinks(p.read_text(encoding="utf-8"))
+        for w in s:
+            if w not in slugs:
+                missing.append(f"{p.name}: [[{w}]] not found")
+    return missing


### PR DESCRIPTION
## Summary
- centralize node slug generation and enforce canonical `[[Slug]]` wikilinks
- enrich notes with Dataview sections, prereqs, see-also links, and slug validation
- validate exported pages for broken wikilinks after export

## Testing
- `pytest -q`
- `python -m py_compile mark2mind/utils/slugs.py mark2mind/utils/validate_links.py mark2mind/pipeline/stages/enrich_notes.py mark2mind/pipeline/runner.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5bed984648322839d4b1f3bdd351b