### PR TITLE
Add progress reporting and parallel prerequisite selection

### DIFF
--- a/mark2mind/pipeline/export/markdown.py
+++ b/mark2mind/pipeline/export/markdown.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from pathlib import Path
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 from slugify import slugify
 
 class MarkdownExporter:
@@ -35,6 +35,7 @@ class MarkdownExporter:
         out_md_path: Path,
         pages_dir: Path,
         link_folder_name: str,
+        progress: Optional[Any] = None,
     ):
         """
         - Writes <file_name>.markmap.md with links like: [Node](<file_name>/<node>.md)
@@ -48,4 +49,5 @@ class MarkdownExporter:
             markmap_md_path=str(out_md_path),
             pages_dir=str(pages_dir),
             link_folder_name=link_folder_name,
+            progress=progress,
         )

--- a/mark2mind/pipeline/runner.py
+++ b/mark2mind/pipeline/runner.py
@@ -41,6 +41,8 @@ from mark2mind.chains.map_content_mindmap_chain import ContentMappingChain
 from mark2mind.chains.generate_questions_chain import GenerateQuestionsChain
 from mark2mind.chains.answer_questions_chain import AnswerQuestionsChain
 from mark2mind.pipeline.stages.bullets import BulletsStage
+from mark2mind.utils.exporters import to_camel_nospace
+from mark2mind.utils.validate_links import validate_pages
 
 class StepRunner:
     def __init__(
@@ -343,6 +345,7 @@ class StepRunner:
                         out_md_path=markmap_out_path,
                         pages_dir=pages_dir,
                         link_folder_name=base_name,
+                        progress=progress,
                     )
                     self.console.log(f"✅ Markmap markdown saved to: {markmap_out_path}")
                     # Link validator


### PR DESCRIPTION
## Summary
- Show progress while exporting markmap pages and validate links
- Parallelize prerequisite selection for leaf notes with progress feedback
- Support progress reporting in markdown and page exporters

## Testing
- `pytest -q`
- `python -m py_compile mark2mind/pipeline/runner.py mark2mind/pipeline/stages/enrich_notes.py mark2mind/pipeline/export/markdown.py mark2mind/utils/exporters.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5c9a509e48322911d714ca8143c0e