### PR TITLE
Refine note exports and wikilink validation

### DIFF
--- a/mark2mind/pipeline/stages/enrich_notes.py
+++ b/mark2mind/pipeline/stages/enrich_notes.py
@@ -240,13 +240,7 @@ class EnrichMarkmapNotesStage:
                 )
                 # store in summaries optionally blank
                 summaries[nid] = summaries.get(nid,"")
-                n.setdefault("content_refs", []).append({
-                    "element_id": f"note::{nid}",
-                    "type": "paragraph",
-                    "element_caption": "Teaching note",
-                    "markdown": "",  # frontmatter+body injected later
-                    "created_at": datetime.utcnow().isoformat(timespec="seconds")+"Z",
-                })
+                # Do not pre-seed an empty "Teaching note" ref for branches
                 n["_generated_body"] = self._fix_wikilinks(body, allowed_links)
                 progress.advance(t)
             progress.finish(t)
@@ -360,7 +354,7 @@ class EnrichMarkmapNotesStage:
             )
 
             dv_pre = (
-                "## Pre-reqs\n"
+                "## Prereqs\n"
                 "```dataviewjs\n"
                 "// Render clickable prereqs from frontmatter `prereqs`\n"
                 "const items = dv.current().prereqs ?? [];\n"
@@ -373,15 +367,15 @@ class EnrichMarkmapNotesStage:
                 "```\n\n"
             )
 
-
-            synthetic = f"{fm}\n{dv_see}{dv_pre}{body}"
+            # Frontmatter, then body, then DV sections at the end
+            synthetic = f"{fm}\n{body}\n\n{dv_pre}{dv_see}"
             # ensure only one synthetic note ref and keep existing refs
             refs = n.setdefault("content_refs", [])
             # put synthetic first
             refs.insert(0, {
                 "element_id": f"note::{nid}",
                 "type": "paragraph",
-                "element_caption": "Teaching note",
+                "element_caption": "",  # no wrapper title
                 "markdown": synthetic,
                 "created_at": datetime.utcnow().isoformat(timespec="seconds")+"Z",
             })

--- a/mark2mind/utils/exporters.py
+++ b/mark2mind/utils/exporters.py
@@ -202,13 +202,16 @@ def _render_node_page(node: Dict[str, Any]) -> str:
                 lines.append("")  # spacer
                 # replace the first ref body with the remainder (without YAML header)
                 refs[0]["markdown"] = rest
-    lines.append(f"# {title}")
-    lines.append("")
+    # Add a single H1 only if the first ref does not already start with the same H1
+    first_md = (refs[0].get("markdown") or "").lstrip() if refs else ""
+    first_line = first_md.splitlines()[0].strip() if first_md else ""
+    has_same_h1 = first_line.startswith("#") and first_line[1:].strip().lower() == title.lower()
+    if not has_same_h1:
+        lines.append(f"# {title}")
+        lines.append("")
     if not refs:
         lines.append("> No content refs.")
         return "\n".join(lines) + "\n"
-    lines.append("## Content")
-    lines.append("")
     for ref in refs:
         rtype = (ref.get("type") or "").lower()
         cap = ref.get("element_caption") or ""
@@ -222,8 +225,9 @@ def _render_node_page(node: Dict[str, Any]) -> str:
                 lines.append(a)
             lines.append("")
         else:
-            if cap:
-                lines.append(f"### {cap}")
+            # Suppress the "Teaching note" subheading wrapper
+            if cap and cap.strip().lower() != "teaching note":
+                lines.append(f"### {cap.strip()}")
             md = (ref.get("markdown") or "").strip()
             if md:
                 lines.append(md)

--- a/mark2mind/utils/validate_links.py
+++ b/mark2mind/utils/validate_links.py
@@ -3,7 +3,10 @@ from pathlib import Path
 
 
 def collect_wikilinks(text: str) -> set[str]:
-    raw = {m.group(1).split("|", 1)[0] for m in re.finditer(r"\[\[([^\]]+)\]\]", text)}
+    # Ignore fenced code blocks ```...``` and inline code `...`
+    stripped = re.sub(r"```.*?```", "", text, flags=re.DOTALL)
+    stripped = re.sub(r"`[^`]*`", "", stripped)
+    raw = {m.group(1).split("|", 1)[0] for m in re.finditer(r"\[\[([^\]]+)\]\]", stripped)}
     # take last path segment and strip .md
     norm = set()
     for r in raw:


### PR DESCRIPTION
## Summary
- avoid duplicate titles and remove "Teaching note" wrappers in node page exports
- place prereq/see-also blocks after note bodies without extra wrapper titles
- skip wikilinks inside fenced or inline code during validation

## Testing
- `python -m py_compile mark2mind/utils/exporters.py mark2mind/pipeline/stages/enrich_notes.py mark2mind/utils/validate_links.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b612f0ac788322ba2b1f75497b4470